### PR TITLE
feat: add Autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "shikwasa",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A web audio player born for podcasts, made with love by a podcast enthusiast. It is equipped with playback speed and forward/backward controls, and is best paired with your podcasting website.",
   "main": "dist/shikwasa.cjs.js",
   "dependencies": {},
   "devDependencies": {
+    "autoprefixer": "^9.6.1",
     "eslint": "^6.1.0",
     "gh-pages": "^2.0.1",
     "parcel-bundler": "^1.12.3",
@@ -33,5 +34,9 @@
     "playback"
   ],
   "license": "MIT",
-  "repository": "github:jessuni/shikwasa"
+  "repository": "github:jessuni/shikwasa",
+  "browserslist": [
+    "last 1 version",
+    "> 1%"
+  ]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import postcss from 'rollup-plugin-postcss'
+import autoprefixer from 'autoprefixer'
 import html from 'rollup-plugin-html'
 import minify from 'rollup-plugin-babel-minify'
 import replace from 'rollup-plugin-replace'
@@ -19,7 +20,10 @@ const plugins = [
   }),
   postcss({
     extract: true,
-    minimize: true,
+    minimize: true, // Use cssnano
+    plugins: [
+      autoprefixer()
+    ],
   }),
   html({
     include: 'src/template/*.html',

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -3,16 +3,6 @@
     transform: rotate(360deg);
   }
 }
-@-webkit-keyframes rotate {
-  to {
-    -webkit-transform: rotate(360deg);
-  }
-}
-@-moz-keyframes rotate {
-  to {
-    transform: rotate(360deg);
-  }
-}
 
 .shk {
   position: inherit;
@@ -38,8 +28,6 @@
 }
 .shk.Seeking {
   cursor: grabbing;
-  cursor: -moz-grabbing;
-  cursor: -webkit-grabbing;
 }
 .shk_cover {
   position: relative;
@@ -67,8 +55,6 @@
 }
 .shk_btn {
   appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   background: transparent;
   border: none;
   outline: none;
@@ -126,9 +112,6 @@
 .shk_text,
 .shk_controls,
 .shk_time {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 .shk_subtitle {
@@ -235,13 +218,9 @@ svg.shk_btn_mute,
   width: 8px;
   cursor: move;
   cursor: grab;
-  cursor: -moz-grab;
-  cursor: -webkit-grab;
 }
 .bar-handle:active {
   cursor: grabbing;
-  cursor: -moz-grabbing;
-  cursor: -webkit-grabbing;
 }
 .shk_bottom {
   position: absolute;
@@ -265,8 +244,6 @@ svg.shk_btn_mute,
   width: 12px;
   height: 12px;
   animation: rotate 1.4s linear infinite;
-  -webkit-animation: rotate 1.4s linear infinite;
-  -moz-animation: rotate 1.4s linear infinite;
   position: relative;
 }
 .shk_visuallyhidden:not(:focus):not(:active) {


### PR DESCRIPTION
Avoiding handwritten prefixes leads to many compatibility problems.

### Before

```css
@-webkit-keyframes rotate {
  to {
    -webkit-transform: rotate(360deg);
  }
}
@-moz-keyframes rotate {
  to {
    transform: rotate(360deg);
  }
}
```

### After

```css
@-webkit-keyframes rotate {
  to {
    -webkit-transform: rotate(360deg);
            transform: rotate(360deg);
  }
}
@keyframes rotate {
  to {
    -webkit-transform: rotate(360deg);
            transform: rotate(360deg);
  }
}
```