### PR TITLE
ci: update virtual server version

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,7 @@ jobs:
 
   cypress-run:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     strategy:
       fail-fast: false


### PR DESCRIPTION
Github no longer supports `ubuntu-16.04` in actions, so we need to upgrade to the latest version for cypress to work.