### PR TITLE
ci: update virtual server version

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -59,7 +59,7 @@ jobs:
   build:
 
     name: Build
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
Forgot to update the virtual server for the build script in last PR.
This PR will allow github actions to run in `ubuntu-latest`. 