### PR TITLE
fix(ui): include icons for each instance

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -10,12 +10,10 @@ let cooldown = true
 export default class UI {
   constructor(options) {
     this.mounted = false
-    if (!document.querySelector('.shk-icons')) {
-      this.icons = createElement({
-        className: 'shk-icons',
-        innerHTML: IconComp,
-      })
-    }
+    this.icons = createElement({
+      className: 'shk-icons',
+      innerHTML: IconComp,
+    })
     this.initEl()
     this.initOptions(options)
   }


### PR DESCRIPTION
Icons used to be mounted on the first instance's container only, and were shared among other player instances on the same page. But destroying the first instance will cause icon reference loss. Since appending the icon set outside the assigned container and reference it globally is not an option, the behavior is now reverted back to one icon set per player.

Fixed #44 .