### PR TITLE
fix: error occurred when destroying the player instance

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -29,4 +29,8 @@ export default class Events {
     console.error(`Shikwasa: unknown event name: ${name}`)
     return null
   }
+
+  destroy() {
+    this.events = {}
+  }
 }

--- a/src/player.js
+++ b/src/player.js
@@ -39,6 +39,7 @@ class Player {
     this._canplay = false
     this._dragging = false
     this.events = new Events()
+    this._eventListeners = {}
     this.options = handleOptions(options)
     this.renderComponents()
     this.initUI(this.options)
@@ -191,9 +192,14 @@ class Player {
       this.audio = new Audio()
       this.initAudioEvents()
       this.events.audioEvents.forEach((name) => {
-        this.audio.addEventListener(name, (e) => {
+        const listener = (e) => {
           this.events.trigger(name, e)
-        })
+        }
+        this.audio.addEventListener(name, listener)
+        if (!this._eventListeners[name]) {
+          this._eventListeners[name] = []
+        }
+        this._eventListeners[name].push(listener)
       })
       this.audio.preload = this.options.preload
       this.muted = this.options.muted
@@ -385,6 +391,12 @@ class Player {
   }
 
   destroyAudio() {
+    this.events.audioEvents.forEach((name) => {
+      if (this._eventListeners[name] && this._eventListeners[name].length) {
+        this._eventListeners[name].forEach(listener => this.audio.removeEventListener(name, listener))
+      }
+    })
+    this._eventListeners = {}
     this.audio.pause()
     this.audio.src = ''
     this.audio.load()

--- a/src/player.js
+++ b/src/player.js
@@ -39,7 +39,6 @@ class Player {
     this._canplay = false
     this._dragging = false
     this.events = new Events()
-    this._eventListeners = {}
     this.options = handleOptions(options)
     this.renderComponents()
     this.initUI(this.options)
@@ -192,14 +191,9 @@ class Player {
       this.audio = new Audio()
       this.initAudioEvents()
       this.events.audioEvents.forEach((name) => {
-        const listener = (e) => {
+        this.audio.addEventListener(name, (e) => {
           this.events.trigger(name, e)
-        }
-        this.audio.addEventListener(name, listener)
-        if (!this._eventListeners[name]) {
-          this._eventListeners[name] = []
-        }
-        this._eventListeners[name].push(listener)
+        })
       })
       this.audio.preload = this.options.preload
       this.muted = this.options.muted
@@ -391,12 +385,6 @@ class Player {
   }
 
   destroyAudio() {
-    this.events.audioEvents.forEach((name) => {
-      if (this._eventListeners[name] && this._eventListeners[name].length) {
-        this._eventListeners[name].forEach(listener => this.audio.removeEventListener(name, listener))
-      }
-    })
-    this._eventListeners = {}
     this.audio.pause()
     this.audio.src = ''
     this.audio.load()
@@ -404,6 +392,7 @@ class Player {
   }
 
   destroy() {
+    this.events.destroy()
     this.destroyAudio()
     this.ui.destroy()
     Object.keys(this.comps).forEach((k) => {


### PR DESCRIPTION
As described in issue #60 , when destroying a player instance, the following error occurred:
```
shikwasa.min.js:1 Uncaught TypeError: Cannot read properties of null (reading 'currentTime')
    at shikwasa.min.js:1:24819
    at shikwasa.min.js:1:20192
    at Array.forEach (<anonymous>)
    at w.trigger (shikwasa.min.js:1:20181)
    at Audio.b (shikwasa.min.js:1:23566)
```
It is because `player.destroy()` calls `this.destroyAudio()`:

https://github.com/jessuni/shikwasa/blob/446b28e03ed5f150558a4161ac1c4105693880db/src/player.js#L394-L404

And `this.destroyAudio()` sets `this.audio.src` to `''` and sets the `this.audio` to null:

https://github.com/jessuni/shikwasa/blob/446b28e03ed5f150558a4161ac1c4105693880db/src/player.js#L387-L392

The change in `this.audio.src` triggers the `timeupdate` event. In the callback function of the `timeupdate` event, it reads `this.audio.currentTime` which caused this error. Because `this.audio` is set to null by `this.destroyAudio()` before.

https://github.com/jessuni/shikwasa/blob/446b28e03ed5f150558a4161ac1c4105693880db/src/player.js#L259-L263

So we need to remove all event listeners at the same time as we destroy the audio.