### PR TITLE
chore(package): fix exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     ".": {
       "import": "./dist/shikwasa.es.js",
       "require": "./dist/shikwasa.cjs.js"
+    },
+    "./dist/style.css": {
+      "import": "./dist/style.css",
+      "require": "./dist/style.css"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
The stylesheet cannot be imported due to the encapsulation of the `exports` field in `package.json` (#72). Fixed by adding an exported subpath for the stylesheet.