### PR TITLE
Allow to seek to a more precise time, not just whole seconds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "shikwasa",
-  "version": "2.2.1",
+  "name": "@anson0370/shikwasa",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "shikwasa",
-      "version": "2.2.1",
+      "name": "@anson0370/shikwasa",
+      "version": "2.2.2",
       "license": "MIT",
       "devDependencies": {
         "@vitejs/plugin-legacy": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "shikwasa",
-  "version": "2.2.1",
+  "name": "@anson0370/shikwasa",
+  "version": "2.2.3",
   "description": "A web audio player born for podcasts. With chapters, playback speed and forward/backward controls, it is best paired with your podcasting website.",
   "files": [
     "dist"
@@ -50,7 +50,9 @@
     "chapter"
   ],
   "license": "MIT",
-  "repository": "github:jessuni/shikwasa",
+  "repository": {
+    "url": "git+ssh://git@github.com/anson0370/shikwasa.git"
+  },
   "browserslist": [
     ">0.2%",
     "not ie <= 8"

--- a/src/player.js
+++ b/src/player.js
@@ -188,6 +188,7 @@ class Player {
         })
       })
       this.audio.preload = this.options.preload
+      this.audio.playbackRate = this.options.initSpeed
       this.muted = this.options.muted
       this.update(this.options.audio)
     }

--- a/src/player.js
+++ b/src/player.js
@@ -329,7 +329,7 @@ class Player {
 
   seek(time) {
     if (!this.seekable) return
-    time = parseInt(time)
+    time = parseFloat(time)
     if (isNaN(time)) {
       console.error('Shikwasa: seeking time is NaN')
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,6 +56,9 @@ export function handleOptions(options) {
   if (_options.speedOptions.length > 1) {
     _options.speedOptions.sort((a, b) => a - b)
   }
+  if (!_options.initSpeed || _options.speedOptions.indexOf(_options.initSpeed) === -1) {
+    _options.initSpeed = 1
+  }
   return _options
 }
 


### PR DESCRIPTION
In certain scenarios, we may need more precise time control, such as starting playback from a specific subtitle. The previous parseInt behavior could result in an offset of up to one second.